### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/csedevil/9acefbd9-fbe6-4cc4-b587-8dcd1ad0c00e/1f801296-4a06-4ca9-b337-a7746a165bf8/_apis/work/boardbadge/1981c3a9-ec17-4262-9cac-a70b2c66e3b9)](https://dev.azure.com/csedevil/9acefbd9-fbe6-4cc4-b587-8dcd1ad0c00e/_boards/board/t/1f801296-4a06-4ca9-b337-a7746a165bf8/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1115](https://dev.azure.com/csedevil/9acefbd9-fbe6-4cc4-b587-8dcd1ad0c00e/_workitems/edit/1115). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.